### PR TITLE
Change tileserver

### DIFF
--- a/resources/views/edit/add-fact.phtml
+++ b/resources/views/edit/add-fact.phtml
@@ -38,9 +38,9 @@ use Ramsey\Uuid\Uuid;
                                           ($map_bounds[0][1] + $map_bounds[1][1]) / 2.0,
                                       ],
                 'provider'        => [
-                    'url'     => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    'url'     => 'https://tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png',
                     'options' => [
-                        'attribution' => '<a href="https://www.openstreetmap.org/copyright">&copy; OpenStreetMap</a> contributors',
+                    'attribution' => 'Tile style - from the <a href="https://www.hotosm.org">Humanitarian OpenStreetMap Team </a>, hosting - from <a href="https://openstreetmap.fr">OSM France</a>',
                         'max_zoom'    => 19
                     ]
                 ],


### PR DESCRIPTION
Hi there! I propose to change the tile server and map style. According to the <a href="https://operations.osmfoundation.org/policies/tiles/"> Tile Usage Policy</a>, using Standart map stile by third-party projects is not desirable. Instead, I suggest using the Humanitarian style from the Humanitarian OSM Team. He, moreover, is much more beautiful )